### PR TITLE
Fix: Updates Octocat's gif link

### DIFF
--- a/_layouts/repo.html
+++ b/_layouts/repo.html
@@ -28,7 +28,7 @@ layout: default
     try opening the <a href="https://github.com/{{page.repo}}">repository</a> directly.
 
     <br>
-    <img style="margin: 0px auto;" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif"
+    <img style="margin: 0px auto;" src="https://github.githubassets.com/images/spinners/octocat-spinner-128.gif"
       height="128" width="128">
   </div>
 </div>


### PR DESCRIPTION
The current URL gives 404