### PR TITLE
Fix: iterating over collection

### DIFF
--- a/_layouts/portfolio.html
+++ b/_layouts/portfolio.html
@@ -25,7 +25,7 @@ layout: default
 <script src="/js/geopattern.min.js"></script>
 <script>
   var patterns = ['octogons', 'plusSigns', 'xes', 'squares', 'nestedSquares', 'concentricCircles']
-  projects = document.getElementsByClassName('project');
+  projects = [...document.getElementsByClassName('project')];
   for(var i in projects){
     var project = projects[i];
     var pattern = GeoPattern.generate(project.getAttribute('data-title'), {


### PR DESCRIPTION
`getElementsByClassName` returns a `Collection`. Iterating over collection causes this issue:

![Screenshot from 2020-12-21 19-13-21](https://user-images.githubusercontent.com/32809272/102783264-abcc3200-43c0-11eb-9ddf-de2515f5958e.png)
---
Fix: Convert to array